### PR TITLE
Migrate from moor_flutter to moor_ffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # moor_shared
 
-A new Flutter project.
+An example project to demonstrate how moor can be used on multiple platforms
+(Web, android, iOS, macOS and Linux).
+
+__Note__: You need to install the Android NDK to run this app on Android
+devices. You can get the NDK in the [SDK Manager](https://developer.android.com/studio/intro/update.html#sdk-manager)
+of Android Studio.
 
 ## Getting Started
 

--- a/lib/data/blocs/bloc.dart
+++ b/lib/data/blocs/bloc.dart
@@ -1,4 +1,4 @@
-import 'package:moor_flutter/moor_flutter.dart';
+import 'package:moor/moor.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../database/database.dart';
@@ -84,5 +84,9 @@ class TodoAppBloc {
     }
 
     db.deleteCategory(category);
+  }
+
+  void dispose() {
+    _allCategories.close();
   }
 }

--- a/lib/data/database/database/mobile.dart
+++ b/lib/data/database/database/mobile.dart
@@ -1,22 +1,29 @@
 import 'dart:io';
 
-import 'package:moor_flutter/moor_flutter.dart';
-import 'package:moor/moor_vm.dart';
+import 'package:moor/moor.dart';
+import 'package:moor_ffi/moor_ffi.dart';
+
+import 'package:path_provider/path_provider.dart' as paths;
+import 'package:path/path.dart' as p;
 
 import '../database.dart';
 
 Database constructDb({bool logStatements = false}) {
   if (Platform.isIOS || Platform.isAndroid) {
-    return Database(FlutterQueryExecutor.inDatabaseFolder(
-        path: 'db.sqlite', logStatements: logStatements));
+    final executor = LazyDatabase(() async {
+      final dataDir = await paths.getApplicationDocumentsDirectory();
+      final dbFile = File(p.join(dataDir.path, 'db.sqlite'));
+      return VmDatabase(dbFile, logStatements: logStatements);
+    });
+    return Database(executor);
   }
   if (Platform.isMacOS || Platform.isLinux) {
     final file = File('db.sqlite');
-    return Database(VMDatabase(file, logStatements: logStatements));
+    return Database(VmDatabase(file, logStatements: logStatements));
   }
   // if (Platform.isWindows) {
   //   final file = File('db.sqlite');
   //   return Database(VMDatabase(file, logStatements: logStatements));
   // }
-  return Database(VMDatabase.memory(logStatements: logStatements));
+  return Database(VmDatabase.memory(logStatements: logStatements));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void dispose() {
     super.dispose();
+    bloc.dispose();
   }
 
   @override

--- a/lib/ui/home/screen.dart
+++ b/lib/ui/home/screen.dart
@@ -28,8 +28,6 @@ class HomeScreenState extends State<HomeScreen> {
         title: Text('Todo list'),
       ),
       drawer: CategoriesDrawer(),
-      // A moorAnimatedList automatically animates incoming and leaving items, we only
-      // have to tell it what data to display and how to turn data into widgets.
       body: StreamBuilder<List<EntryWithCategory>>(
         stream: bloc.homeScreenEntries,
         builder: (context, snapshot) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,14 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.38.2"
+    version: "0.37.1+1"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   archive:
     dependency: transitive
     description:
@@ -199,7 +206,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.24"
+    version: "0.1.21+1"
   glob:
     dependency: transitive
     description:
@@ -283,7 +290,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.24"
+    version: "0.3.21+1"
   logging:
     dependency: transitive
     description:
@@ -316,24 +323,26 @@ packages:
     dependency: "direct main"
     description:
       path: "moor/"
-      ref: ffi
-      resolved-ref: "78bb23a7d1b36a559a78319fa297a30074635d23"
+      ref: develop
+      resolved-ref: "87c50de1e1ad53c371b473c3108c8020c9d6f1c1"
       url: "git://github.com/simolus3/moor.git"
     source: git
-    version: "1.7.1"
-  moor_flutter:
+    version: "1.7.2"
+  moor_ffi:
     dependency: "direct main"
     description:
-      name: moor_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.7.0"
+      path: "moor_ffi/"
+      ref: develop
+      resolved-ref: "87c50de1e1ad53c371b473c3108c8020c9d6f1c1"
+      url: "git://github.com/simolus3/moor.git"
+    source: git
+    version: "0.0.1"
   moor_generator:
     dependency: "direct dev"
     description:
       path: "moor_generator/"
-      ref: ffi
-      resolved-ref: "78bb23a7d1b36a559a78319fa297a30074635d23"
+      ref: develop
+      resolved-ref: "87c50de1e1ad53c371b473c3108c8020c9d6f1c1"
       url: "git://github.com/simolus3/moor.git"
     source: git
     version: "1.7.1"
@@ -352,12 +361,19 @@ packages:
     source: hosted
     version: "1.0.10"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   pedantic:
     dependency: transitive
     description:
@@ -372,6 +388,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
   pool:
     dependency: transitive
     description:
@@ -468,13 +491,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.5"
-  sqflite:
-    dependency: transitive
-    description:
-      name: sqflite
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.6+4"
   sqlparser:
     dependency: transitive
     description:
@@ -581,5 +597,5 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
-  flutter: ">=1.2.1 <2.0.0"
+  dart: ">=2.5.0-dev <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.5.0-dev <3.0.0"
 
 dependencies:
   flutter:
@@ -16,8 +16,12 @@ dependencies:
   rxdart: ^0.22.2
   intl: ^0.16.0
 
-  # Mobile
-  moor_flutter: ^1.7.0
+  # Database for mobile and Desktop
+  moor_ffi: ^0.0.1
+  
+  # Helper to find the database path on mobile
+  path_provider: ^1.3.0
+  path: ^1.6.4
 
   # Web
 
@@ -32,12 +36,17 @@ dependency_overrides:
   moor:
     git:
       url: git://github.com/simolus3/moor.git
-      ref: ffi
+      ref: develop
       path: moor/
+  moor_ffi:
+    git:
+      url: git://github.com/simolus3/moor.git
+      ref: develop
+      path: moor_ffi/
   moor_generator:
     git:
       url: git://github.com/simolus3/moor.git
-      ref: ffi
+      ref: develop
       path: moor_generator/
 
 flutter:


### PR DESCRIPTION
Hi, I've made some adoptions to use `moor_ffi` instead of `moor_flutter` on Android and iOS. As this switches moor to the `develop` branch which already contains breaking changes for the next major release, this PR is a bit bigger than it could have been. The relevant changes are all in `mobile.dart` to open the database.

I tested this on Android and Linux, the database was working fine on both platforms. I did have some rendering issues on Linux, but I don't think that moor has anything to do with that. It should work on iOS and macOS as well, but I can't verify that until Monday.

Rather unrelated question: Do you intend to keep this repository open? I would like to link it from the [examples section](https://moor.simonbinder.eu/docs/examples/) in moor's documentation, if that's ok.