### PR TITLE
Switch to moor beta branch

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -323,8 +323,8 @@ packages:
     dependency: "direct main"
     description:
       path: "moor/"
-      ref: develop
-      resolved-ref: "87c50de1e1ad53c371b473c3108c8020c9d6f1c1"
+      ref: beta
+      resolved-ref: cef3fd0bbe30d9f6dd823c0e616fe581e2a5ddc7
       url: "git://github.com/simolus3/moor.git"
     source: git
     version: "1.7.2"
@@ -332,8 +332,8 @@ packages:
     dependency: "direct main"
     description:
       path: "moor_ffi/"
-      ref: develop
-      resolved-ref: "87c50de1e1ad53c371b473c3108c8020c9d6f1c1"
+      ref: beta
+      resolved-ref: cef3fd0bbe30d9f6dd823c0e616fe581e2a5ddc7
       url: "git://github.com/simolus3/moor.git"
     source: git
     version: "0.0.1"
@@ -341,8 +341,8 @@ packages:
     dependency: "direct dev"
     description:
       path: "moor_generator/"
-      ref: develop
-      resolved-ref: "87c50de1e1ad53c371b473c3108c8020c9d6f1c1"
+      ref: beta
+      resolved-ref: cef3fd0bbe30d9f6dd823c0e616fe581e2a5ddc7
       url: "git://github.com/simolus3/moor.git"
     source: git
     version: "1.7.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,17 +36,17 @@ dependency_overrides:
   moor:
     git:
       url: git://github.com/simolus3/moor.git
-      ref: develop
+      ref: beta
       path: moor/
   moor_ffi:
     git:
       url: git://github.com/simolus3/moor.git
-      ref: develop
+      ref: beta
       path: moor_ffi/
   moor_generator:
     git:
       url: git://github.com/simolus3/moor.git
-      ref: develop
+      ref: beta
       path: moor_generator/
 
 flutter:


### PR DESCRIPTION
Switch from the current `develop` branch to the `beta` branch of moor.

There are no major changes since the last PR, but the beta branch is updated less frequently and is generally more stable. On macOS and iOS, `moor_ffi` will now attempt to open `/usr/lib/libsqlite3.dylib` instead of just `libsqlite3.dylib`.

Please let me know if you run into any issues - I hope to release a first version of `moor_ffi` very soon :pray: 