### PR TITLE
Use moor 2.0 from pub

### DIFF
--- a/lib/data/database/database.g.dart
+++ b/lib/data/database/database.g.dart
@@ -6,7 +6,7 @@ part of 'database.dart';
 // MoorGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps
+// ignore_for_file: unnecessary_brace_in_string_interps, unnecessary_this
 class TodoEntry extends DataClass implements Insertable<TodoEntry> {
   final int id;
   final String content;
@@ -95,10 +95,10 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
   bool operator ==(other) =>
       identical(this, other) ||
       (other is TodoEntry &&
-          other.id == id &&
-          other.content == content &&
-          other.targetDate == targetDate &&
-          other.category == category);
+          other.id == this.id &&
+          other.content == this.content &&
+          other.targetDate == this.targetDate &&
+          other.category == this.category);
 }
 
 class TodosCompanion extends UpdateCompanion<TodoEntry> {
@@ -112,6 +112,12 @@ class TodosCompanion extends UpdateCompanion<TodoEntry> {
     this.targetDate = const Value.absent(),
     this.category = const Value.absent(),
   });
+  TodosCompanion.insert({
+    this.id = const Value.absent(),
+    @required String content,
+    this.targetDate = const Value.absent(),
+    this.category = const Value.absent(),
+  }) : content = Value(content);
   TodosCompanion copyWith(
       {Value<int> id,
       Value<String> content,
@@ -302,7 +308,9 @@ class Category extends DataClass implements Insertable<Category> {
   @override
   bool operator ==(other) =>
       identical(this, other) ||
-      (other is Category && other.id == id && other.description == description);
+      (other is Category &&
+          other.id == this.id &&
+          other.description == this.description);
 }
 
 class CategoriesCompanion extends UpdateCompanion<Category> {
@@ -312,6 +320,10 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
     this.id = const Value.absent(),
     this.description = const Value.absent(),
   });
+  CategoriesCompanion.insert({
+    this.id = const Value.absent(),
+    @required String description,
+  }) : description = Value(description);
   CategoriesCompanion copyWith({Value<int> id, Value<String> description}) {
     return CategoriesCompanion(
       id: id ?? this.id,
@@ -406,15 +418,10 @@ abstract class _$Database extends GeneratedDatabase {
   $TodosTable get todos => _todos ??= $TodosTable(this);
   $CategoriesTable _categories;
   $CategoriesTable get categories => _categories ??= $CategoriesTable(this);
-  Future<int> _resetCategory(
-      int var1,
-      {@Deprecated('No longer needed with Moor 1.6 - see the changelog for details')
-          QueryEngine operateOn}) {
-    return (operateOn ?? this).customUpdate(
+  Future<int> _resetCategory(int var1) {
+    return customUpdate(
       'UPDATE todos SET category = NULL WHERE category = ?',
-      variables: [
-        Variable.withInt(var1),
-      ],
+      variables: [Variable.withInt(var1)],
       updates: {todos},
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,13 +249,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
-  image:
-    dependency: transitive
-    description:
-      name: image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.4"
   intl:
     dependency: "direct main"
     description:
@@ -322,30 +315,24 @@ packages:
   moor:
     dependency: "direct main"
     description:
-      path: "moor/"
-      ref: beta
-      resolved-ref: cef3fd0bbe30d9f6dd823c0e616fe581e2a5ddc7
-      url: "git://github.com/simolus3/moor.git"
-    source: git
-    version: "1.7.2"
+      name: moor
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   moor_ffi:
     dependency: "direct main"
     description:
-      path: "moor_ffi/"
-      ref: beta
-      resolved-ref: cef3fd0bbe30d9f6dd823c0e616fe581e2a5ddc7
-      url: "git://github.com/simolus3/moor.git"
-    source: git
+      name: moor_ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   moor_generator:
     dependency: "direct dev"
     description:
-      path: "moor_generator/"
-      ref: beta
-      resolved-ref: cef3fd0bbe30d9f6dd823c0e616fe581e2a5ddc7
-      url: "git://github.com/simolus3/moor.git"
-    source: git
-    version: "1.7.1"
+      name: moor_generator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -381,13 +368,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0+1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.4.0"
   platform:
     dependency: transitive
     description:
@@ -497,7 +477,7 @@ packages:
       name: sqlparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   stack_trace:
     dependency: transitive
     description:
@@ -582,13 +562,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.15"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.5.0"
   yaml:
     dependency: transitive
     description:
@@ -597,5 +570,5 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.5.0-dev <3.0.0"
+  dart: ">=2.5.0-dev <2.6.0"
   flutter: ">=0.1.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   
   # Dart
   cupertino_icons: ^0.1.2
-  moor: ^1.7.1
+  moor: ^2.0.0
   rxdart: ^0.22.2
   intl: ^0.16.0
 
@@ -26,28 +26,11 @@ dependencies:
   # Web
 
 dev_dependencies:
-  moor_generator: ^1.7.1
+  moor_generator: ^2.0.0
   build_runner: ^1.6.7
   build_web_compilers: ^2.3.0
   flutter_test:
     sdk: flutter
-
-dependency_overrides:
-  moor:
-    git:
-      url: git://github.com/simolus3/moor.git
-      ref: beta
-      path: moor/
-  moor_ffi:
-    git:
-      url: git://github.com/simolus3/moor.git
-      ref: beta
-      path: moor_ffi/
-  moor_generator:
-    git:
-      url: git://github.com/simolus3/moor.git
-      ref: beta
-      path: moor_generator/
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Now that moor 2.0 is available on pub, we can drop the git dependency and go back to the pub version.